### PR TITLE
Human readable support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 bincode = "1.2"
+serde_derive = "1.0"
+serde-xml-rs = "0.4"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Hey, I added support for serializing and deserializing with serde from human readable (text) formats, xml, json, yaml etc.

I'm using serde-xml-rs to test this serialization/deserialization to/from xml, but I don't see anything that should prevent it from working on any other serializers/deserializers for human readable formats. A more general approach would probably be to use a custom serializer and deserializer instead to prevent the extra dev dependencies, or to use the serde-test crate to avoid using specific formats in the tests to begin with. Let me know if you want me to pursue either direction.